### PR TITLE
Update editor to use modelValue for Vue 3

### DIFF
--- a/example/read-only/viewer.py
+++ b/example/read-only/viewer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server()
+server = get_server(client_type="vue2")
 state, ctrl = server.state, server.controller
 
 

--- a/trame_code/widgets/code.py
+++ b/trame_code/widgets/code.py
@@ -1,5 +1,7 @@
 """Module compatible with vue2 and vue3. To use it, you need to install **trame-code**"""
+
 from trame_client.widgets.core import AbstractElement
+
 from .. import module
 
 __all__ = [
@@ -21,8 +23,9 @@ class Editor(HtmlElement):
 
     Properties:
 
-    :param v_model:
     :param options:
+    :param value:
+    :param model_value:
     :param theme:
     :param language:
     :param textmate:
@@ -40,6 +43,8 @@ class Editor(HtmlElement):
         )
         self._attr_names += [
             "options",
+            "value",
+            ("model_value", "modelValue"),
             "theme",
             "language",
             "textmate",

--- a/trame_code/widgets/code.py
+++ b/trame_code/widgets/code.py
@@ -21,8 +21,8 @@ class Editor(HtmlElement):
 
     Properties:
 
+    :param v_model:
     :param options:
-    :param value:
     :param theme:
     :param language:
     :param textmate:
@@ -40,7 +40,6 @@ class Editor(HtmlElement):
         )
         self._attr_names += [
             "options",
-            "value",
             "theme",
             "language",
             "textmate",

--- a/vue-components/src/components/Editor.js
+++ b/vue-components/src/components/Editor.js
@@ -109,7 +109,7 @@ export default {
     }
 
     this.editor = monaco.editor.create(this.$el, {
-      value: this.modelValue,
+      value: this.modelValue || this.value,
       language: this.language,
       theme: this.theme,
       ...this.options,

--- a/vue-components/src/components/Editor.js
+++ b/vue-components/src/components/Editor.js
@@ -9,7 +9,7 @@ import * as monaco from "monaco-editor";
 export default {
   name: "VSEditor",
   props: {
-    value: {
+    modelValue: {
       type: String,
       default: "",
     },
@@ -34,8 +34,8 @@ export default {
     },
   },
   watch: {
-    value(v) {
-      if (this.editor) {
+    modelValue(v) {
+      if (this.editor && this.editor.getValue() !== v) {
         this.editor.setValue(v);
       }
     },
@@ -102,7 +102,7 @@ export default {
     }
 
     this.editor = monaco.editor.create(this.$el, {
-      value: this.value,
+      value: this.modelValue,
       language: this.language,
       theme: this.theme,
       ...this.options,
@@ -112,9 +112,10 @@ export default {
       provider.injectCSS();
     }
 
-    this.editor.onDidChangeModelContent(() =>
-      this.$emit("input", this.editor.getValue())
-    );
+    this.editor.onDidChangeModelContent(() => {
+      this.$emit("update:modelValue", this.editor.getValue());
+      this.$emit("input", this.editor.getValue());
+    });
   },
   beforeUnmount() {
     this.editor.dispose();

--- a/vue-components/src/components/Editor.js
+++ b/vue-components/src/components/Editor.js
@@ -11,7 +11,9 @@ export default {
   props: {
     modelValue: {
       type: String,
-      default: "",
+    },
+    value: {
+      type: String,
     },
     options: {
       type: Object,
@@ -35,7 +37,12 @@ export default {
   },
   watch: {
     modelValue(v) {
-      if (this.editor && this.editor.getValue() !== v) {
+      if (this.editor && v !== undefined && this.editor.getValue() !== v) {
+        this.editor.setValue(v);
+      }
+    },
+    value(v) {
+      if (this.editor && v !== undefined && this.editor.getValue() !== v) {
         this.editor.setValue(v);
       }
     },
@@ -112,9 +119,16 @@ export default {
       provider.injectCSS();
     }
 
+    this.lastValue = this.editor.getValue();
+
     this.editor.onDidChangeModelContent(() => {
-      this.$emit("update:modelValue", this.editor.getValue());
-      this.$emit("input", this.editor.getValue());
+      const newValue = this.editor.getValue();
+      if (this.lastValue === newValue) {
+        return;
+      }
+      this.lastValue = newValue;
+      this.$emit("update:modelValue", newValue);
+      this.$emit("input", newValue);
     });
   },
   beforeUnmount() {


### PR DESCRIPTION
Closes #3

Fixes value not being 2-way bound, does not fix `input` being triggered twice.

Tested [here](https://github.com/MattTheCuber/vuetify-to-trame-converter/commit/d834b63a0abc3c649ebd01ff8591517365a36bd9).

https://github.com/user-attachments/assets/df6ca634-34aa-468c-ac23-9bbef2bf83fe
